### PR TITLE
Error: Non-file stream objects are not supported with SigV4 in AWS.S3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "aws-sdk": "^2.49.0",
     "lodash": "^4.17.4",
     "progress": "^2.0.0",
-    "s3": "^4.4.0"
+    "s3-node-client": "^4.4.3"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/s3_uploader.js
+++ b/s3_uploader.js
@@ -1,4 +1,4 @@
-const s3 = require('s3');
+const s3 = require('s3-node-client');
 const ProgressBar = require('progress');
 const _ = require('lodash');
 const aws = require('aws-sdk');


### PR DESCRIPTION
Replace `s3` dependency with a fixed version `s3-node-client` to support S3 bucket regions that require SigV4 signatures for uploading, e.g. "eu-central-1".

**Test possible via:**
```
"devDependencies": {
    "webpack-s3-uploader": "git+https://git@github.com/pascalbayer/webpack-s3-uploader.git"
}
```