### PR TITLE
Add session token to cloudfront invalidation for STS users

### DIFF
--- a/s3_uploader.js
+++ b/s3_uploader.js
@@ -181,7 +181,7 @@ module.exports = class S3Plugin {
     });
 
     const promise = new Promise((resolve, reject) => {
-      upload.on('error', reject);
+      upload.on('error', (err) => reject('\nfailed uplaoding file: ' + file + ' err: ' + err));
       upload.on('end', () => resolve(file));
     });
 
@@ -193,10 +193,11 @@ module.exports = class S3Plugin {
 
     return new Promise((resolve, reject) => {
       if (cloudfrontInvalidateOptions.DistributionId) {
-        const { accessKeyId, secretAccessKey } = clientConfig.s3Options;
+        const { accessKeyId, secretAccessKey, sessionToken } = clientConfig.s3Options;
         const cloudfront = new aws.CloudFront({
           accessKeyId,
           secretAccessKey,
+          sessionToken
         });
 
         cloudfront.createInvalidation({
@@ -208,7 +209,13 @@ module.exports = class S3Plugin {
               Items: cloudfrontInvalidateOptions.Items,
             },
           },
-        }, (err, res) => (err ? reject(err) : resolve(res.Id)));
+        }, (err, res) => {
+			if(err) {
+              console.log('\n[ERROR] error crating cloudfront invalidation: ' + err);
+			}
+
+            err ? reject(err) : resolve(res.Id);
+        });
       }
       return resolve(null);
     });

--- a/s3_uploader.js
+++ b/s3_uploader.js
@@ -210,11 +210,11 @@ module.exports = class S3Plugin {
             },
           },
         }, (err, res) => {
-			if(err) {
-              console.log('\n[ERROR] error crating cloudfront invalidation: ' + err);
-			}
+          if (err) {
+            console.log('\n[ERROR] error creating cloudfront invalidation: ' + err);
+          }
 
-            err ? reject(err) : resolve(res.Id);
+          err ? reject(err) : resolve(res.Id);
         });
       }
       return resolve(null);


### PR DESCRIPTION
* Adds sessionToken to the cloudfrontinvalidation auth props so STS users can authenticate successfully. WIthout the session token that accompanies an STS users access and secret key, all auth calls fail.
* Return the file that caused uploading to fail for easy debugging
* Show error message when cloudfront invalidation fails for easy debugging

Love the plugin! Saves me a ton of time! The code is really clean and concise. I use an IAM role I obtain from STS and need to add the session token for my creds to work.

I tested with an STS cred set WITH a security token, and then with a regular account WITHOUT the security token and verified it does not break backwards.

I tested the error messages as well. Here is sample output from a failed upload

Uploading [                           -------------------------------------------------------------------------] 27% 0.1sError: 
failed uplaoding file: /local/home/user/Website/src/Website/build/manifest/manifest.json err: BadRequest: null
    at handleErrors (/local/home/user/Website/src/Website/node_modules/webpack-s3-uploader/s3_uploader.js:33:6)
    at getAssetFiles.then.then.then.then.catch.e (/local/home/user/Website/src/Website/node_modules/webpack-s3-uploader/s3_uploader.js:92:21)
    at run (/local/home/user/Website/src/Website/node_modules/core-js/modules/es6.promise.js:75:22)
    at /local/home/user/Website/src/node_modules/core-js/modules/es6.promise.js:92:30
    at flush (/local/home/user/Website/src/Website/node_modules/core-js/modules/_microtask.js:18:9)
    at process._tickCallback (internal/process/next_tick.js:172:11)

Adding the file name in there saves me a ton of time figuring out which file is causing the failure, and then I can go update my excludes as needed without manually accounting for all my generated files.

What do you think about the changes?